### PR TITLE
Fix 0 amount bug in spend_allowance

### DIFF
--- a/token/src/allowance.rs
+++ b/token/src/allowance.rs
@@ -53,11 +53,13 @@ pub fn spend_allowance(e: &Env, from: Address, spender: Address, amount: i128) {
     if allowance.amount < amount {
         panic!("insufficient allowance");
     }
-    write_allowance(
-        e,
-        from,
-        spender,
-        allowance.amount - amount,
-        allowance.expiration_ledger,
-    );
+    if amount > 0 {
+        write_allowance(
+            e,
+            from,
+            spender,
+            allowance.amount - amount,
+            allowance.expiration_ledger,
+        );
+    }
 }


### PR DESCRIPTION
This fixes a low severity bug in a token contract in this repo.

This repo contains code copied from the Soroban example token,
code which recieved a fix in the upstream repo that has not been applied here.

The fix in question, from December, is in this commit:

https://github.com/stellar/soroban-examples/commit/c7947120dc3ef92345d6e019737065d916cfae9d#diff-02d9e91ec617d641664acc20ed164964099f2b96a099109d42cdbb80d44087aeR56

From reading, I think the main consequence of this bug is that a
previously-unauthorized spender calling transfer_from can write a 0 to the
temporary storage for their own allowance; though it also seems to allow
unintended behavior like allowing authorized spenders to extend the ttl of the
allowance without transfering.

As far as I know this bug does not have a security impact.
